### PR TITLE
feat(annotations): add package annotation

### DIFF
--- a/sassdoc/index.js
+++ b/sassdoc/index.js
@@ -93,9 +93,14 @@ const theme = themeleon(__dirname, function (t) {
             json: function (context) {
                 return JSON.stringify(context);
             },
-            github: function (file, line) {
-                const url = 'https://github.com/IgniteUI/igniteui-angular/tree/master/projects/igniteui-angular/src/lib/core/styles/';
-                return `${url}${file}#L${line}`;
+            github: function (file, line, package) {
+                let source = {
+                    default: 'https://github.com/IgniteUI/igniteui-angular/tree/master/projects/igniteui-angular/src/lib/core/styles/',
+                    theming: 'https://github.com/IgniteUI/igniteui-theming/tree/master/sass/',
+
+                }
+
+                return `${source[package]}${file}#L${line}`;
             },
             typeClass: function (context) {
                 switch (context) {
@@ -294,6 +299,35 @@ module.exports = function (dest, ctx) {
      */
     return theme.apply(this, arguments);
 };
+
+/**
+ * A package annotation to determine the base URL for code definitions.
+ */
+function packageAnnotation () {
+    return {
+        name: 'package',
+        parse: function(text) {
+            return {
+                name: text.trim()
+            };
+        },
+        resolve: function(data) {
+            data.forEach((item) => {
+                if (item.package.name === 'auto') {
+                    item.package.name = 'default';
+                }
+            });
+        },
+        default: function() {
+            return {
+                name: 'auto'
+            }
+        },
+        multiple: false
+    }
+}
+
+module.exports.annotations = [packageAnnotation];
 
 function getConfigData(envs, templateLang) {
     let {

--- a/sassdoc/views/partials/github.hbs
+++ b/sassdoc/views/partials/github.hbs
@@ -2,6 +2,6 @@
     <header class="defined-in__header" role="group">
         <span class="defined-in__icon"></span>
         <h4 class="defined-in__title">&nbsp;{{#localize}}Defined in{{/localize}}:</h4>
-        <a class="defined-in__path" href="{{github file.path commentRange.start}}" target="_blank">{{file.path}}:{{commentRange.start}}</a>
+        <a class="defined-in__path" href="{{github file.path commentRange.start package.name}}" target="_blank">{{file.path}}:{{commentRange.start}}</a>
     </header>
 </article>


### PR DESCRIPTION
Related https://github.com/IgniteUI/igniteui-angular/issues/12691

This PR adds a SassDoc `@package` annotation to the the theme. It is used to 'mark' sass modules or items so that merging multiple Sass sources like [Ignite UI Theming](https://github.com/IgniteUI/igniteui-theming) and [Ignite UI for Angular](https://github.com/IgniteUI/igniteui-theming) can produce correct "Defined in" GitHub URLs.

Steps to validate:

1. Run `npm run build`
2. Run `npm pack`
3. Grab the produced tar file
4. Check out https://github.com/IgniteUI/igniteui-theming/pull/70
5. Run `npm install path-to-tar` in the checked out branch
6. Run `npm build:docs` in the checked out branch
7. Run `npm serve:docs` in the checked out branch
8. Verify that clicking on the "Defined in" links points to the correct location in the source code in the Ignite UI Theming repo.

Prior to this PR, the links would point to the Ignite UI for Angular repo, resulting in 404 errors.